### PR TITLE
Judy/fix get challenge

### DIFF
--- a/src/main/java/com/example/jaksim/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/example/jaksim/challenge/controller/ChallengeController.java
@@ -68,13 +68,6 @@ public class ChallengeController {
             @Parameter(description = "챌린지 생성 요청 데이터", required = true)
             @RequestBody ChallengeCreateRequest request,
             @RequestHeader(value = "user-uuid", required = false) String userUuid) {
-
-        // 테스트용 기본값 설정 (실제로는 랜덤 UUID 사용)
-        if (userUuid == null || userUuid.isEmpty()) {
-            userUuid = UUID.randomUUID().toString(); // 테스트용 임시 UUID
-            System.out.println("테스트용 UUID 생성: " + userUuid);
-        }
-
         ResponseDto response = challengeService.createChallenge(request, userUuid);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }

--- a/src/main/java/com/example/jaksim/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/example/jaksim/challenge/controller/ChallengeController.java
@@ -36,9 +36,9 @@ public class ChallengeController {
     @Operation(summary = "챌린지 목록 조회", description = "페이지를 기준으로 챌린지 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<ResponseDto> getChallenges(
-        @Parameter(description = "페이지 번호 (기본값: 1)", example = "1") 
-        @RequestParam(defaultValue = "1") int page) {
-        List<ChallengeListResponse> challenges = challengeService.getChallenges(page);     
+            @Parameter(description = "페이지 번호 (기본값: 0)", example = "0")
+            @RequestParam(defaultValue = "0") int page) {
+        ChallengeListResponse challenges = challengeService.getChallenges(page);
 
         return new ResponseEntity<>(ResponseDto.setSuccess(200, "챌린지 목록 조회 성공", challenges), HttpStatus.OK);
     }
@@ -65,12 +65,16 @@ public class ChallengeController {
     @Operation(summary = "챌린지 생성", description = "새로운 챌린지를 생성합니다.")
     @PostMapping("/create")
     public ResponseEntity<ResponseDto> createChallenge(
-        @Parameter(description = "챌린지 생성 요청 데이터", required = true) 
-        @RequestBody ChallengeCreateRequest request,
-        @Parameter(description = "JWT 인증 사용자 UUID", hidden = true) 
-        @AuthenticationPrincipal UserDetails userDetails) {
-        String userUuid = ((UserDetailsImplement) userDetails).getUsername(); 
-        System.out.println(userUuid);
+            @Parameter(description = "챌린지 생성 요청 데이터", required = true)
+            @RequestBody ChallengeCreateRequest request,
+            @RequestHeader(value = "user-uuid", required = false) String userUuid) {
+
+        // 테스트용 기본값 설정 (실제로는 랜덤 UUID 사용)
+        if (userUuid == null || userUuid.isEmpty()) {
+            userUuid = UUID.randomUUID().toString(); // 테스트용 임시 UUID
+            System.out.println("테스트용 UUID 생성: " + userUuid);
+        }
+
         ResponseDto response = challengeService.createChallenge(request, userUuid);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }

--- a/src/main/java/com/example/jaksim/challenge/dto/challenge/ChallengeJoinRequest.java
+++ b/src/main/java/com/example/jaksim/challenge/dto/challenge/ChallengeJoinRequest.java
@@ -1,0 +1,8 @@
+package com.example.jaksim.challenge.dto.challenge;
+
+import lombok.Getter;
+
+@Getter
+public class ChallengeJoinRequest {
+    private Long challengeId;
+}

--- a/src/main/java/com/example/jaksim/challenge/dto/challenge/ChallengeListResponse.java
+++ b/src/main/java/com/example/jaksim/challenge/dto/challenge/ChallengeListResponse.java
@@ -1,21 +1,36 @@
 package com.example.jaksim.challenge.dto.challenge;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ChallengeListResponse {
 
 	private List<ChallengeSummary> challenges;
 
+	public ChallengeListResponse() {
+		this.challenges = new ArrayList<>();
+	}
+
+	// 챌린지 요약 리스트를 받는 생성자
 	public ChallengeListResponse(List<ChallengeSummary> challenges) {
 		this.challenges = challenges;
 	}
 
+	// 단일 챌린지 정보를 받아 리스트로 리턴하는 생성자
 	public ChallengeListResponse(Long challengeId, String name, String backgroundImage, String creatorUuid, LocalDateTime createdAt) {
+		ChallengeSummary summary = new ChallengeSummary();
+		summary.setChallengeId(challengeId);
+		summary.setName(name);
+		summary.setBackgroundImage(backgroundImage);
+		summary.setCreatorUuid(creatorUuid);
+		summary.setCreatedAt(createdAt);
+
+		this.challenges = new ArrayList<>();
+		this.challenges.add(summary);
 	}
 
 	// Getters and Setters
-
 	public List<ChallengeSummary> getChallenges() {
 		return challenges;
 	}
@@ -30,12 +45,25 @@ public class ChallengeListResponse {
 		private String name;
 		private String backgroundImage;
 		private boolean isPublic;
-		
+		private String creatorUuid;
+		private LocalDateTime createdAt;
 
-		// 진행중인 미션 수
+		// 기본 생성자 추가
+		public ChallengeSummary() {
+		}
+
+		// 전체 필드를 초기화하는 생성자 추가
+		public ChallengeSummary(Long challengeId, String name, String backgroundImage,
+								boolean isPublic, String creatorUuid, LocalDateTime createdAt) {
+			this.challengeId = challengeId;
+			this.name = name;
+			this.backgroundImage = backgroundImage;
+			this.isPublic = isPublic;
+			this.creatorUuid = creatorUuid;
+			this.createdAt = createdAt;
+		}
 
 		// Getters and Setters
-
 		public Long getChallengeId() {
 			return challengeId;
 		}
@@ -66,6 +94,22 @@ public class ChallengeListResponse {
 
 		public void setPublic(boolean isPublic) {
 			this.isPublic = isPublic;
+		}
+
+		public String getCreatorUuid() {
+			return creatorUuid;
+		}
+
+		public void setCreatorUuid(String creatorUuid) {
+			this.creatorUuid = creatorUuid;
+		}
+
+		public LocalDateTime getCreatedAt() {
+			return createdAt;
+		}
+
+		public void setCreatedAt(LocalDateTime createdAt) {
+			this.createdAt = createdAt;
 		}
 	}
 }

--- a/src/main/java/com/example/jaksim/challenge/dto/challenge/ChallengeListResponse.java
+++ b/src/main/java/com/example/jaksim/challenge/dto/challenge/ChallengeListResponse.java
@@ -47,12 +47,13 @@ public class ChallengeListResponse {
 		private boolean isPublic;
 		private String creatorUuid;
 		private LocalDateTime createdAt;
+		private int remainingPoint;
+		private int activeMissionsCount;
+		private int participantsCount;
 
-		// 기본 생성자 추가
 		public ChallengeSummary() {
 		}
 
-		// 전체 필드를 초기화하는 생성자 추가
 		public ChallengeSummary(Long challengeId, String name, String backgroundImage,
 								boolean isPublic, String creatorUuid, LocalDateTime createdAt) {
 			this.challengeId = challengeId;
@@ -61,6 +62,20 @@ public class ChallengeListResponse {
 			this.isPublic = isPublic;
 			this.creatorUuid = creatorUuid;
 			this.createdAt = createdAt;
+		}
+
+		public ChallengeSummary(Long challengeId, String name, String backgroundImage,
+								boolean isPublic, String creatorUuid, LocalDateTime createdAt,
+								int remainingPoint, int activeMissionsCount, int participantsCount) {
+			this.challengeId = challengeId;
+			this.name = name;
+			this.backgroundImage = backgroundImage;
+			this.isPublic = isPublic;
+			this.creatorUuid = creatorUuid;
+			this.createdAt = createdAt;
+			this.remainingPoint = remainingPoint;
+			this.activeMissionsCount = activeMissionsCount;
+			this.participantsCount = participantsCount;
 		}
 
 		// Getters and Setters
@@ -110,6 +125,30 @@ public class ChallengeListResponse {
 
 		public void setCreatedAt(LocalDateTime createdAt) {
 			this.createdAt = createdAt;
+		}
+
+		public int getRemainingPoint() {
+			return remainingPoint;
+		}
+
+		public void setRemainingPoint(int remainingPoint) {
+			this.remainingPoint = remainingPoint;
+		}
+
+		public int getActiveMissionsCount() {
+			return activeMissionsCount;
+		}
+
+		public void setActiveMissionsCount(int activeMissionsCount) {
+			this.activeMissionsCount = activeMissionsCount;
+		}
+
+		public int getParticipantsCount() {
+			return participantsCount;
+		}
+
+		public void setParticipantsCount(int participantsCount) {
+			this.participantsCount = participantsCount;
 		}
 	}
 }

--- a/src/main/java/com/example/jaksim/challenge/entity/Mission.java
+++ b/src/main/java/com/example/jaksim/challenge/entity/Mission.java
@@ -38,6 +38,9 @@ public class Mission {
     @Column(name = "completion_points", nullable = false)
     private int completionPoints;
 
+    @Column(name = "is_active")
+    private int isActive;
+
     @Column(name = "image_url")
     private String backgroundImages;
 

--- a/src/main/java/com/example/jaksim/challenge/entity/UsersTargetRewards.java
+++ b/src/main/java/com/example/jaksim/challenge/entity/UsersTargetRewards.java
@@ -1,0 +1,48 @@
+package com.example.jaksim.challenge.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "users_target_rewards")
+public class UsersTargetRewards {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_target_reward_id")
+    private Integer userTargetRewardId;
+
+    @Column(name = "user_id", columnDefinition = "BINARY(16)")
+    private UUID userId;
+
+    @ManyToOne
+    @JoinColumn(name = "reward_id")
+    private Reward reward;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "is_active")
+    private Boolean isActive = true;
+
+    public UsersTargetRewards() {
+    }
+
+    public UsersTargetRewards(UUID userId, Reward reward) {
+        this.userId = userId;
+        this.reward = reward;
+    }
+}

--- a/src/main/java/com/example/jaksim/challenge/repository/MissionRepository.java
+++ b/src/main/java/com/example/jaksim/challenge/repository/MissionRepository.java
@@ -1,5 +1,6 @@
 package com.example.jaksim.challenge.repository;
 
+import com.example.jaksim.challenge.entity.Challenge;
 import com.example.jaksim.challenge.entity.Mission;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,5 +11,6 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     Optional<Mission> findByMissionId(Long missionId);
     List<Mission> findAllByChallengeChallengeId(Long challengeId);
     Optional<Mission> findByMissionIdAndChallengeChallengeId(Long missionId, Long challengeId);
-
+    int countByChallengeAndIsActive(Challenge challenge, int isActive);
+    List<Mission> findByChallengeAndIsActiveOrderByCompletionPointsAsc(Challenge challenge, int isActive);
 }

--- a/src/main/java/com/example/jaksim/challenge/repository/RewardRepository.java
+++ b/src/main/java/com/example/jaksim/challenge/repository/RewardRepository.java
@@ -1,5 +1,6 @@
 package com.example.jaksim.challenge.repository;
 
+import com.example.jaksim.challenge.entity.Challenge;
 import com.example.jaksim.challenge.entity.Reward;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
@@ -8,5 +9,6 @@ public interface RewardRepository extends JpaRepository<Reward, Long> {
 
     // 챌린지 ID로 리워드를 조회
     List<Reward> findByChallengeChallengeId(Long challengeId);
+    List<Reward> findByChallenge(Challenge challenge);
 
 }

--- a/src/main/java/com/example/jaksim/challenge/repository/UserChallengeRepository.java
+++ b/src/main/java/com/example/jaksim/challenge/repository/UserChallengeRepository.java
@@ -1,6 +1,8 @@
 package com.example.jaksim.challenge.repository;
 
+import com.example.jaksim.challenge.entity.Challenge;
 import com.example.jaksim.challenge.entity.UserChallenge;
+import com.example.jaksim.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,4 +10,5 @@ import java.util.UUID;
 
 public interface UserChallengeRepository extends JpaRepository<UserChallenge, Long> {
     Optional<UserChallenge> findByUserUserUuidAndChallengeChallengeId(UUID userUuid, Long challengeId);
+    Optional<UserChallenge> findByUserAndChallenge(User user, Challenge challenge);
 }

--- a/src/main/java/com/example/jaksim/challenge/repository/UsersTargetRewardsRepository.java
+++ b/src/main/java/com/example/jaksim/challenge/repository/UsersTargetRewardsRepository.java
@@ -1,0 +1,11 @@
+package com.example.jaksim.challenge.repository;
+
+import com.example.jaksim.challenge.entity.UsersTargetRewards;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+import java.util.List;
+
+public interface UsersTargetRewardsRepository extends JpaRepository<UsersTargetRewards, Long> {
+    List<UsersTargetRewards> findByUserIdAndIsActiveTrue(UUID userId);
+}

--- a/src/main/java/com/example/jaksim/challenge/service/ChallengeService.java
+++ b/src/main/java/com/example/jaksim/challenge/service/ChallengeService.java
@@ -34,18 +34,21 @@ public class ChallengeService {
 	}
 
 	// 챌린지 목록 조회
-	public List<ChallengeListResponse> getChallenges(int page) {
+	public ChallengeListResponse getChallenges(int page) {
 		Pageable pageable = PageRequest.of(page, 10); // 페이지당 10개 챌린지
 		Page<Challenge> challengePage = challengeRepository.findAll(pageable);
 
-		return challengePage.getContent().stream()
-			.map(challenge -> new ChallengeListResponse(
-				challenge.getChallengeId(),
-				challenge.getName(),
-				challenge.getBackgroundImage(),
-				challenge.getCreatorUuid(),
-				challenge.getCreatedAt()))
-			.collect(Collectors.toList());
+		List<ChallengeListResponse.ChallengeSummary> summaries = challengePage.getContent().stream()
+				.map(challenge -> new ChallengeListResponse.ChallengeSummary(
+						challenge.getChallengeId(),
+						challenge.getName(),
+						challenge.getBackgroundImage(),
+						challenge.isPublic(),
+						challenge.getCreatorUuid(),
+						challenge.getCreatedAt()))
+				.collect(Collectors.toList());
+
+		return new ChallengeListResponse(summaries);
 	}
 
 	// 챌린지 개인별 조회

--- a/src/main/java/com/example/jaksim/challenge/service/ChallengeService.java
+++ b/src/main/java/com/example/jaksim/challenge/service/ChallengeService.java
@@ -4,22 +4,20 @@ import com.example.jaksim.challenge.dto.challenge.ChallengeCreateRequest;
 import com.example.jaksim.challenge.dto.challenge.ChallengeDetailResponse;
 import com.example.jaksim.challenge.dto.challenge.ChallengeListResponse;
 import com.example.jaksim.challenge.dto.challenge.ParticipantResponse;
-import com.example.jaksim.challenge.entity.Challenge;
-import com.example.jaksim.challenge.repository.ChallengeRepository;
+import com.example.jaksim.challenge.entity.*;
+import com.example.jaksim.challenge.repository.*;
 import com.example.jaksim.common.ResponseDto;
 import com.example.jaksim.user.entity.User;
 import com.example.jaksim.user.repository.UserRepository;
 
-import java.util.Optional;
+import java.util.*;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,11 +25,19 @@ public class ChallengeService {
 
 	private final ChallengeRepository challengeRepository;
 	private final UserRepository userRepository;
+	private final MissionRepository missionRepository;
+	private final UserChallengeRepository userChallengeRepository;
+	private final RewardRepository rewardRepository;
+	private final UsersTargetRewardsRepository usersTargetRewardsRepository;
 
-	public ChallengeService(ChallengeRepository challengeRepository, UserRepository userRepository) {
+	public ChallengeService(ChallengeRepository challengeRepository, UserRepository userRepository, MissionRepository missionRepository, UserChallengeRepository userChallengeRepository, RewardRepository rewardRepository, UsersTargetRewardsRepository usersTargetRewardsRepository) {
 		this.challengeRepository = challengeRepository;
 		this.userRepository = userRepository;
-	}
+        this.missionRepository = missionRepository;
+        this.userChallengeRepository = userChallengeRepository;
+        this.rewardRepository = rewardRepository;
+        this.usersTargetRewardsRepository = usersTargetRewardsRepository;
+    }
 
 	// 챌린지 목록 조회
 	public ChallengeListResponse getChallenges(int page) {
@@ -52,20 +58,43 @@ public class ChallengeService {
 	}
 
 	// 챌린지 개인별 조회
-	public List<ChallengeListResponse> getPersonalChallenges(int page, String userUuid){
-		Pageable pageable = PageRequest.of(page, 10); 
-		
+	public Map<String, Object> getPersonalChallenges(int page, String userUuid) {
 		List<Long> challengeIds = userRepository.findByUserUuid(UUID.fromString(userUuid)).get().getChallengeIds();
-
+		Pageable pageable = PageRequest.of(page, 10);
 		Page<Challenge> challengePage = challengeRepository.findByChallengeIdIn(challengeIds, pageable);
-		return challengePage.getContent().stream()
-			.map(challenge -> new ChallengeListResponse(
-				challenge.getChallengeId(),
-				challenge.getName(),
-				challenge.getBackgroundImage(),
-				challenge.getCreatorUuid(),
-				challenge.getCreatedAt()))
-			.collect(Collectors.toList());
+
+		Optional<User> optionalUser = userRepository.findByUserUuid(UUID.fromString(userUuid));
+		if (optionalUser.isEmpty()) {
+			throw new NullPointerException("유저를 찾을 수 없습니다.");
+		}
+		List<ChallengeListResponse.ChallengeSummary> summaries = challengePage.getContent().stream()
+				.map(challenge -> {
+					Long challengeId = challenge.getChallengeId();
+					int activeMissionsCount = getMissionCount(challengeId);
+					int remainingPoint = calculateRemainingPoint(challengeId, userUuid);
+
+					return new ChallengeListResponse.ChallengeSummary(
+							challengeId,
+							challenge.getName(),
+							challenge.getBackgroundImage(),
+							challenge.isPublic(),
+							challenge.getCreatorUuid(),
+							challenge.getCreatedAt(),
+							remainingPoint,
+							activeMissionsCount,
+							challenge.getCurrentParticipants()
+					);
+				})
+				.collect(Collectors.toList());
+		Map<String, Object> responseData = new HashMap<>();
+		responseData.put("challenges", summaries);
+		responseData.put("pageInfo", Map.of(
+				"currentPage", challengePage.getNumber(),
+				"totalPages", challengePage.getTotalPages(),
+				"totalElements", challengePage.getTotalElements(),
+				"size", challengePage.getSize()
+		));
+		return responseData;
 	}
 
 	// 챌린지 상세 조회
@@ -140,7 +169,7 @@ public class ChallengeService {
 										user.getUsername(),
 										0            
 								))
-								.collect(Collectors.toList());
+								.toList();
 
 			int currentParticipants = participantsList.size();
 			
@@ -166,11 +195,20 @@ public class ChallengeService {
 			}
 		
 		Optional<User> optionalUser = userRepository.findByUserUuid(userUuid);
-		if(!optionalUser.isPresent()){
+		if(optionalUser.isEmpty()){
 			throw new NullPointerException("유저 정보가 잘못되었습니다.");
 		}
 		
 		User currentUser = optionalUser.get();
+
+		UserChallenge userChallenge = userChallengeRepository.findByUserAndChallenge(currentUser, challenge)
+				.orElseGet(() -> {
+					UserChallenge newUserChallenge = new UserChallenge();
+					newUserChallenge.setUser(currentUser);
+					newUserChallenge.setChallenge(challenge);
+					newUserChallenge.setPoints(0);
+					return userChallengeRepository.save(newUserChallenge);
+				});
 
 		List<Long> challengeIds = currentUser.getChallengeIds();
 		if(!challengeIds.contains(challenge.getChallengeId())){
@@ -202,9 +240,51 @@ public class ChallengeService {
 				challenge.getTags(),
 				challenge.getCreatedAt(),
 				challenge.getUpdatedAt(),
-				challenge.getCreatorUuid().toString(),
+                challenge.getCreatorUuid(),
 				participantsList
 				);
 	}
-	
+
+	private int getMissionCount(Long challengeId) {
+		return challengeRepository.findById(challengeId)
+				.map(challenge -> missionRepository.countByChallengeAndIsActive(challenge, 1))
+				.orElse(0);
+	}
+
+	private int calculateRemainingPoint(Long challengeId, String userUuid) {
+		User user = userRepository.findByUserUuid(UUID.fromString(userUuid))
+				.orElseThrow(() -> new NullPointerException("유저를 찾을 수 없습니다."));
+		Challenge challenge = challengeRepository.findByChallengeId(challengeId);
+		if (challenge == null) {
+			throw new NullPointerException("챌린지를 찾을 수 없습니다.");
+		}
+		UserChallenge userChallenge = userChallengeRepository.findByUserAndChallenge(user, challenge)
+				.orElseThrow(() -> new NullPointerException("유저 챌린지 정보를 찾을 수 없습니다."));
+		int currentPoints = userChallenge.getPoints();
+
+		List<Reward> targetRewards = usersTargetRewardsRepository.findByUserIdAndIsActiveTrue(user.getUserUuid())
+				.stream()
+				.map(UsersTargetRewards::getReward)
+				.filter(reward -> reward.getChallenge().getChallengeId().equals(challengeId))
+				.toList();
+
+		if (targetRewards.isEmpty()) {
+			return findRewardsPoint(challenge, currentPoints);
+		}
+		Optional<Reward> nearestReward = targetRewards.stream()
+				.filter(reward -> reward.getRequiredPoints() > currentPoints)
+				.min(Comparator.comparingInt(reward -> reward.getRequiredPoints() - currentPoints));
+        return nearestReward.map(reward -> reward.getRequiredPoints() - currentPoints).orElse(0);
+	}
+
+	private int findRewardsPoint(Challenge challenge, int currentPoints) {
+		List<Reward> allRewards = rewardRepository.findByChallenge(challenge);
+		if (allRewards.isEmpty()) {
+			return 0;
+		}
+		Optional<Reward> nearestReward = allRewards.stream()
+				.filter(reward -> reward.getRequiredPoints() > currentPoints)
+				.min(Comparator.comparingInt(Reward::getRequiredPoints));
+        return nearestReward.map(reward -> reward.getRequiredPoints() - currentPoints).orElse(0);
+	}
 }

--- a/src/main/java/com/example/jaksim/common/config/Swagger2Config.java
+++ b/src/main/java/com/example/jaksim/common/config/Swagger2Config.java
@@ -30,47 +30,34 @@ public class Swagger2Config {
                         .name("Apache 2.0")
                         .url("http://www.apache.org/licenses/LICENSE-2.0.html"));
 
-        Server localServer = new Server()
-                .url("http://localhost:8080/")
-                .description("Dev Server");
-
         Server devServer = new Server()
                 .url("http://ec2-43-201-22-201.ap-northeast-2.compute.amazonaws.com/")
                 .description("Dev Server");
+
+        Server localServer = new Server()
+                .url("http://localhost:8080")
+                .description("Local Server");
 
         Server prodServer = new Server()
                 .url("http://jaksim.site/")
                 .description("Production Server");
 
-        SecurityScheme bearerAuth = new SecurityScheme()
+        // AT만 사용하도록 설정
+        SecurityScheme accessToken = new SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
                 .scheme("bearer")
                 .bearerFormat("JWT")
                 .in(SecurityScheme.In.HEADER)
                 .name("Authorization");
 
-        SecurityScheme accessToken = new SecurityScheme()
-                .type(SecurityScheme.Type.APIKEY)
-                .in(SecurityScheme.In.HEADER)
-                .name("AT");
-
-        SecurityScheme refreshToken = new SecurityScheme()
-                .type(SecurityScheme.Type.APIKEY)
-                .in(SecurityScheme.In.HEADER)
-                .name("RT");
-
         SecurityRequirement securityRequirement = new SecurityRequirement()
-                .addList("bearerAuth")
-                .addList("AT")
-                .addList("RT");
+                .addList("AT");
 
         return new OpenAPI()
                 .info(info)
-                .servers(Arrays.asList(localServer, devServer, prodServer))
+                .servers(Arrays.asList(devServer, localServer, prodServer))
                 .components(new Components()
-                        .addSecuritySchemes("bearerAuth", bearerAuth)
-                        .addSecuritySchemes("AT", accessToken)
-                        .addSecuritySchemes("RT", refreshToken))
+                        .addSecuritySchemes("AT", accessToken))
                 .addSecurityItem(securityRequirement);
     }
 }

--- a/src/main/java/com/example/jaksim/common/jwt/JwtUtil.java
+++ b/src/main/java/com/example/jaksim/common/jwt/JwtUtil.java
@@ -16,8 +16,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-
-import com.example.jaksim.common.security.RefreshTokenRepository;
 import com.example.jaksim.common.security.UserDetailsServiceImplement;
 
 import io.jsonwebtoken.*;
@@ -34,20 +32,15 @@ public class JwtUtil {
 	@Value("${jwt.secret.key}")
 	private String secretKey;
 
-	public static final String ACCESS_KEY = "At";
+	public static final String ACCESS_KEY = "Authorization";
 	public static final String REFRESH_KEY = "RT";
-
 	// public static final String AUTHORIZATION_HEADER = "Authorization";
 	public static final String BEARER_PREFIX = "Bearer ";
-
-
 	private static final long ACCESS_TIME =  24 * 60 * 60 * 1000L;
-
 	private static final long REFRESH_TIME = 14 * 24 * 60 * 60 * 1000L;
 
 
 	private final UserDetailsServiceImplement userDetailsServiceImplement;
-	private final RefreshTokenRepository refreshTokenRepository;
 	private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
 	private Key key;
 	private RedisDao redisDao;

--- a/src/main/java/com/example/jaksim/common/security/UserDetailsServiceImplement.java
+++ b/src/main/java/com/example/jaksim/common/security/UserDetailsServiceImplement.java
@@ -1,16 +1,14 @@
 package com.example.jaksim.common.security;
 
-import java.util.UUID;
-
+import com.example.jaksim.login.entity.Login;
+import com.example.jaksim.login.repository.LoginRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import com.example.jaksim.login.entity.Login;
-import com.example.jaksim.login.repository.LoginRepository;
-
-import lombok.RequiredArgsConstructor;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -18,13 +16,18 @@ public class UserDetailsServiceImplement implements UserDetailsService {
 	private final LoginRepository loginRepository;
 
 	@Override
-	public UserDetails loadUserByUsername(String userUuid) throws UsernameNotFoundException {
-
-		Login login = (Login)loginRepository.findByUserUuid(UUID.fromString(userUuid)).orElseThrow(
-			()-> new UsernameNotFoundException("존재하지 않는 유저 네임입니다.")
-		);
-		return new UserDetailsImplement(login, String.valueOf(login.getUserUuid()));
+	public UserDetails loadUserByUsername(String userIdentifier) throws UsernameNotFoundException {
+		try {
+			UUID uuid = UUID.fromString(userIdentifier);
+			Login login = (Login) loginRepository.findByUserUuid(uuid).orElseThrow(
+					() -> new UsernameNotFoundException("존재하지 않는 유저 네임입니다.")
+			);
+			return new UserDetailsImplement(login, String.valueOf(login.getUserUuid()));
+		} catch (IllegalArgumentException e) {
+			Login login = (Login) loginRepository.findByMemberUniqueId(userIdentifier).orElseThrow(
+					() -> new UsernameNotFoundException("존재하지 않는 유저 네임입니다.")
+			);
+			return new UserDetailsImplement(login, String.valueOf(login.getUserUuid()));
+		}
 	}
-
-
 }

--- a/src/main/java/com/example/jaksim/login/service/LoginService.java
+++ b/src/main/java/com/example/jaksim/login/service/LoginService.java
@@ -45,22 +45,20 @@ public class LoginService {
 		login.setUserUuid(userUuid);
 		loginRepository.save(login); // DB에 저장
 
-
 		user.setUserUuid(userUuid);
 		user.setSocial(signUpRequest.getSocial());
 		userRepository.save(user);
 
 		Optional<Login> member = loginRepository.findByMemberUniqueIdAndSocial(String.valueOf(login.getMemberUniqueId()), SocialType.KAKAO);
-		TokenDto tokenDto = jwtUtil.createAllToken(member.get().getMemberUniqueId(), String.valueOf(member.get().getTokenVersion()));
+		TokenDto tokenDto = jwtUtil.createAllToken(String.valueOf(member.get().getUserUuid()), String.valueOf(member.get().getTokenVersion()));
 
 		Map<String, Object> responseData = new HashMap<>();
 		responseData.put("AT",tokenDto.getAccessToken());
-		responseData.put("RT",  tokenDto.getRefreshToken());
+		responseData.put("RT",tokenDto.getRefreshToken());
 		responseData.put("nickname", user.getUsername());
 		responseData.put("social", signUpRequest.getSocial());
 
 		return new ResponseEntity<>(new ResponseDto(209, "로그인에 성공하셨습니다.", responseData), HttpStatus.OK);
-
 	}
 
 	public ResponseEntity<ResponseDto> reissue(String refreshToken) {


### PR DESCRIPTION
1. 스웨거 설정 변경
2. JWT AT > 기본 인증 헤더로 변경 (Authorization)
3. 챌린지 조회 로직 변경
4. 챌린지 코드로 참여 Request DTO 추가
5. 챌린지 유저별 조회 API 엔드포인트 변경
6. 챌린지 유저별 조회 로직에 아래 조건 및 결과값 추가
- 내가 참여한 챌린지 목록만 필터링
- 보상 달성까지의 포인트
- 진행 중인 미션 개수
- 참여 중인 사람 수
7. 유저의 보상 즐겨찾기 추적 테이블 및 엔티티 추가 (User_target_rewards, 6번 로직에 사용)